### PR TITLE
Change in clustTimebin and clustADCs

### DIFF
--- a/ConfigFile.cfg
+++ b/ConfigFile.cfg
@@ -15,6 +15,7 @@ MaxEvents = -1			        ;Number of events to process (-1 to maximum)
 PrintConfiguration = true
 ReadoutType = CMSGE21			;Options CMSGEM and PLAIN
 NumberOfChips = 12
+OneCluster = true
 
 [Sector1]
 Position = 195

--- a/ReadConf.c
+++ b/ReadConf.c
@@ -31,6 +31,7 @@ int ReadConf::LoadConfiguration() {
     Reco = reader.Get("General", "Reco", "All");
     AnalysisType = reader.Get("General", "AnalysisType", "Integral");
     MaxEvents = reader.GetInteger("General", "MaxEvents", 100000000);
+    OneCluster = reader.GetBoolean("General", "OneCluster", false);
     for (int i = 1; i <= 4; i++) {
         Position[i] = reader.GetInteger("Sector"+std::to_string(i), "Position", 0);
         Size[i] = reader.GetInteger("Sector"+std::to_string(i), "Size", 0);

--- a/ReadConf.h
+++ b/ReadConf.h
@@ -23,7 +23,7 @@ public:
     int PedestalCut, Position[9], Size[9], Chips[9], apvIndex[25], NumberOfChips, FecID[25], adcCh[25], DetPlane[25], MaxEvents;
     std::string InputFile, ReadoutType, Reco, AnalysisType, OutputFile;
     double Pitch[9];
-    bool Flip[25], Verbose, PedestalRemoval;
+    bool Flip[25], Verbose, PedestalRemoval, OneCluster;
     int MonitorEvents;
 
 private:


### PR DESCRIPTION
1. clustTimebin
- Changed the way to calculate clustTimebin when saving the cluster found. It should be the sum of time bins into the cluster size.

2. clustADCs
- Changed to fill the clusterADC with the maxPeaks of the hits instead of summing all the ADC channels
- Added one part to choose only one cluster per chip in each event 